### PR TITLE
Update New-UnityLUNThinClone.ps1

### DIFF
--- a/Unity-Powershell/Public/Storage/New-UnityLUNThinClone.ps1
+++ b/Unity-Powershell/Public/Storage/New-UnityLUNThinClone.ps1
@@ -63,6 +63,8 @@ Function New-UnityLUNThinClone {
     [String[]]$host,
     [Parameter(Mandatory = $false,HelpMessage = 'Host access mask')]
     [HostLUNAccessEnum]$accessMask = 'Production',
+    [Parameter(Mandatory = $false,HelpMessage = 'The HLU ID which should be assigned')]
+    [int16]$hluID,
 
     # snapScheduleParameters
     [Parameter(Mandatory = $false,HelpMessage = 'ID of a protection schedule to apply to the storage resource')]
@@ -139,6 +141,7 @@ Function New-UnityLUNThinClone {
                 $HostParam['id'] = $h
               $blockHostAccessParam['host'] = $HostParam
               $blockHostAccessParam['accessMask'] = $accessMask
+              $blockHostAccessParam['hlu'] = $hluID
             $hostAccess += $blockHostAccessParam
           }
 


### PR DESCRIPTION
In case a LUN needs to have the same HLU on all hosts, it could be assigned with the '-hluID' parameter